### PR TITLE
Update sales notes and address storage

### DIFF
--- a/src/components/master-data/Karyawan.tsx
+++ b/src/components/master-data/Karyawan.tsx
@@ -18,6 +18,7 @@ interface KaryawanItem {
   roles: { nama: string } | null;
   email?: string;
   password?: string;
+  gaji?: number | null;
 }
 
 const Karyawan: React.FC = () => {
@@ -35,6 +36,7 @@ const Karyawan: React.FC = () => {
     role_id: '',
     email: '',
     password: '',
+    gaji: null,
   };
 
   const [selectedItem, setSelectedItem, clearSelectedItem] = useFormPersistence<Partial<KaryawanItem>>({
@@ -114,6 +116,11 @@ const Karyawan: React.FC = () => {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
+    if (name === 'gaji') {
+      const numeric = value === '' ? null : Number(value);
+      setSelectedItem(prev => ({ ...prev, gaji: Number.isFinite(numeric as number) ? (numeric as number) : null }));
+      return;
+    }
     setSelectedItem(prev => ({ ...prev, [name]: value }));
   };
 
@@ -122,7 +129,7 @@ const Karyawan: React.FC = () => {
     const toastId = showLoading(modalMode === 'add' ? 'Menambah karyawan...' : 'Menyimpan perubahan...');
 
     if (modalMode === 'add') {
-      const { email, password, first_name, last_name, role_id } = selectedItem;
+      const { email, password, first_name, last_name, role_id, gaji } = selectedItem;
 
       if (!email || !password || !first_name || !role_id) {
         showError('Email, Password, Nama Depan, dan Jabatan harus diisi.');
@@ -130,7 +137,7 @@ const Karyawan: React.FC = () => {
         return;
       }
 
-      const { error: authError } = await supabase.auth.signUp({
+      const { data: signUpRes, error: authError } = await supabase.auth.signUp({
         email,
         password,
         options: {
@@ -138,6 +145,7 @@ const Karyawan: React.FC = () => {
             first_name,
             last_name,
             role_id,
+            gaji: typeof gaji === 'number' ? gaji : null,
           },
         },
       });
@@ -146,6 +154,13 @@ const Karyawan: React.FC = () => {
         // showError('Gagal menambah karyawan: ' + authError.message);
         showError(indoAuthError(authError));
       } else {
+        // Ensure gaji is saved into profiles table as well
+        if (typeof gaji === 'number' && signUpRes?.user?.id) {
+          await supabase
+            .from('profiles')
+            .update({ gaji })
+            .eq('id', signUpRes.user.id);
+        }
         showSuccess('Karyawan berhasil ditambahkan! Akun dibuat.');
         closeModal();
         fetchKaryawan();
@@ -374,6 +389,23 @@ const Karyawan: React.FC = () => {
                       <option key={role.id} value={role.id}>{role.nama}</option>
                     ))}
                   </select>
+                </div>
+                <div>
+                  <label htmlFor="gaji" className="block text-sm font-medium text-gray-700 mb-1">
+                    Gaji (per bulan)
+                  </label>
+                  <input
+                    type="number"
+                    id="gaji"
+                    name="gaji"
+                    value={selectedItem?.gaji ?? ''}
+                    onChange={handleChange}
+                    disabled={modalMode === 'view'}
+                    min={0}
+                    step="1000"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-50"
+                    placeholder="Contoh: 3000000"
+                  />
                 </div>
               </div>
 

--- a/src/components/master-data/Karyawan.tsx
+++ b/src/components/master-data/Karyawan.tsx
@@ -66,7 +66,9 @@ const Karyawan: React.FC = () => {
       showError('Gagal memuat data karyawan.');
       setError(error.message);
     } else {
-      setData(profilesList || []);
+      // Exclude soft-deleted users if fields exist
+      const cleaned = (profilesList || []).filter((p: any) => p?.is_active !== false && !p?.deleted_at);
+      setData(cleaned as any);
     }
     setLoading(false);
   };
@@ -190,10 +192,13 @@ const Karyawan: React.FC = () => {
       return;
     }
     const toastId = showLoading('Menghapus karyawan...');
-    const { error } = await supabase
+    // Soft delete to avoid foreign key and RLS issues
+    const { data: updated, error } = await supabase
       .from('profiles')
-      .delete()
-      .eq('id', id);
+      .update({ is_active: false, deleted_at: new Date().toISOString() })
+      .eq('id', id)
+      .select('id')
+      .single();
 
     if (error) {
       showError('Gagal menghapus karyawan: ' + error.message);

--- a/src/components/master-data/Karyawan.tsx
+++ b/src/components/master-data/Karyawan.tsx
@@ -19,6 +19,7 @@ interface KaryawanItem {
   email?: string;
   password?: string;
   gaji?: number | null;
+  is_active?: boolean | null;
 }
 
 const Karyawan: React.FC = () => {
@@ -37,6 +38,7 @@ const Karyawan: React.FC = () => {
     email: '',
     password: '',
     gaji: null,
+    is_active: true,
   };
 
   const [selectedItem, setSelectedItem, clearSelectedItem] = useFormPersistence<Partial<KaryawanItem>>({
@@ -121,6 +123,10 @@ const Karyawan: React.FC = () => {
     if (name === 'gaji') {
       const numeric = value === '' ? null : Number(value);
       setSelectedItem(prev => ({ ...prev, gaji: Number.isFinite(numeric as number) ? (numeric as number) : null }));
+      return;
+    }
+    if (name === 'is_active') {
+      setSelectedItem(prev => ({ ...prev, is_active: value === 'true' }));
       return;
     }
     setSelectedItem(prev => ({ ...prev, [name]: value }));
@@ -395,6 +401,24 @@ const Karyawan: React.FC = () => {
                     ))}
                   </select>
                 </div>
+                {modalMode !== 'add' && (
+                  <div>
+                    <label htmlFor="is_active" className="block text-sm font-medium text-gray-700 mb-1">
+                      Status
+                    </label>
+                    <select
+                      id="is_active"
+                      name="is_active"
+                      value={(selectedItem?.is_active ?? true) ? 'true' : 'false'}
+                      onChange={handleChange}
+                      disabled={modalMode === 'view'}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-50"
+                    >
+                      <option value="true">Aktif</option>
+                      <option value="false">Nonaktif</option>
+                    </select>
+                  </div>
+                )}
                 <div>
                   <label htmlFor="gaji" className="block text-sm font-medium text-gray-700 mb-1">
                     Gaji (per bulan)

--- a/src/hooks/useSalesOrder.ts
+++ b/src/hooks/useSalesOrder.ts
@@ -30,7 +30,7 @@ const prepareOrderDataForSave = async (
   status: 'pending' | 'paid',
   paymentDetails?: PaymentDetails
 ) => {
-  let orderNotes = formData.notes;
+  let orderNotes = formData.customer_notes; // Save "Catatan" into orders.notes
   if (paymentDetails) {
     orderNotes += `\nPayment Details: ${JSON.stringify(paymentDetails)}`;
   }

--- a/src/pages/Sales.tsx
+++ b/src/pages/Sales.tsx
@@ -133,7 +133,7 @@ const Sales: React.FC = () => {
           '').trim();
   
       const address = (orderFormData.customer_address || '').trim();
-      const notes = (orderFormData.customer_notes || '').trim();
+      // Notes should be saved on orders, not pelanggan
       const normalized = phoneRaw ? normalizePhone(phoneRaw) : null;
   
       // 1) Upsert TANPA .single() → biar dapat array
@@ -145,7 +145,6 @@ const Sales: React.FC = () => {
             telepon: normalized || null,
             // telepon_normalized: normalized, // boleh null kalau phone kosong
             alamat: address || null,
-            catatan: notes || null,
           },
           // { onConflict: 'telepon_normalized' }
         )


### PR DESCRIPTION
Relocate sales `catatan` (notes) storage from the `pelanggan` table to the `orders` table.

---
<a href="https://cursor.com/background-agent?bcId=bc-f33eb11a-2bb1-489c-8069-6f2c4046662f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f33eb11a-2bb1-489c-8069-6f2c4046662f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

